### PR TITLE
[RB-01] Phase 1: mkdocs-material migration, nav restructure, lifecycle badges

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,45 @@
+# Current Status
+
+This page summarises the current state of all active work in the Pushpaka working group.
+
+## Work Items
+
+| ID | Name | Status | Notes |
+|----|------|--------|-------|
+| [I01](./work-items/i01.md) | Concept of Operations V1 | Published | Stable. Foundational risk-category framework (A/B/C/D). |
+| I02 | Commentary on Draft Rules 2021 | Published | Published on iSpirt blog. |
+| I03 | Draft Rules Change Requests | Archived | Aborted. |
+| I04 | Commentary on Drone Rules 2021 | Archived | Aborted. |
+| [I05](./work-items/i05/index.md) | UTM Concept of Operations | Published | Timeline framing under revision. |
+| [I06](./work-items/i06.md) | UTM Technical Standards | Paused | Skeletal draft only. Awaiting direction. |
+| [I07](./work-items/i07.md) | Feedback Sessions: ConOps V1 | Published | Session recordings and materials available. |
+| [I08](./work-items/i08.md) | NIDSP Specification | Draft | Actively being written. DPG-light framing to be added. |
+
+## API Specifications
+
+| Spec | Status | Notes |
+|------|--------|-------|
+| [Registry](./openapi/README.md) | Published | v1.0.17. Source of truth in `docs/openapi/`. |
+| [Flight Authorisation](./openapi/README.md) | Published | Source of truth in `docs/openapi/`. |
+
+## Reference Implementation
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Registry service (Java) | Illustrative | Scoped to I05. Not a production system. |
+| Flight Authorisation service (Java) | Illustrative | Scoped to I05. Not a production system. |
+| DevContainer / SITL integration | Planned | Replaces Vagrantfile. Scheduled for Phase 4. |
+| MAVLink bridge | Planned | Scheduled for Phase 4. |
+
+## Repo Rebaseline Progress
+
+| Phase | Name | Status |
+|-------|------|--------|
+| Phase 0 | Strategic rebaseline & scope lock | Done |
+| Phase 1 | Docs, site & mkdocs-material migration | In progress |
+| Phase 2 | Submodule removal | Pending |
+| Phase 3 | Reference implementation refactor | Pending |
+| Phase 4a | DevContainer | Pending |
+| Phase 4b | MAVLink bridge | Pending |
+| Phase 5 | I08 DPG-light framing | Pending |
+| Phase 6 | Governance | Pending |

--- a/docs/work-items/i01.md
+++ b/docs/work-items/i01.md
@@ -1,3 +1,7 @@
+---
+status: published
+---
+
 # Concept of Operations
 
 ID: `I01`  

--- a/docs/work-items/i05/index.md
+++ b/docs/work-items/i05/index.md
@@ -1,3 +1,7 @@
+---
+status: published
+---
+
 # UTM Concept of Operations
 
 ID: `I05`  

--- a/docs/work-items/i06.md
+++ b/docs/work-items/i06.md
@@ -1,3 +1,7 @@
+---
+status: paused
+---
+
 # UTM Technical Specification
 
 ID: `I06`  

--- a/docs/work-items/i07.md
+++ b/docs/work-items/i07.md
@@ -1,3 +1,7 @@
+---
+status: published
+---
+
 # Feedback Sessions 1-2: Concept of Operations Version 1
 
 ID: `I07`  

--- a/docs/work-items/i08.md
+++ b/docs/work-items/i08.md
@@ -1,8 +1,12 @@
+---
+status: draft
+---
+
 # Interoperable Digital Sky Service Provider Specification
 
-ID: `I08`  
-Status: `WORKING DRAFT`  
-Version: `1`  
+ID: `I08`
+Status: `WORKING DRAFT`
+Version: `1`
 
 **[NIDSP 1.0	11](#nidsp-1.0)**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,39 @@
 site_name: Pushpaka
+site_url: https://ispirt.github.io/pushpaka/
+repo_url: https://github.com/iSPIRT/pushpaka
+repo_name: iSPIRT/pushpaka
+
+theme:
+  name: material
+  palette:
+    primary: indigo
+    accent: indigo
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+
+extra:
+  status:
+    draft: Work in progress
+    published: Published and stable
+    paused: Work paused — awaiting direction
+    archived: No longer active
+
 nav:
   - Home: index.md
-  - work-items/index.md
-  - nomenclature.md
-  - bibliography.md
-theme: pulse
+  - Status: status.md
+  - Work Items:
+    - Overview: work-items/index.md
+    - I01 — ConOps V1: work-items/i01.md
+    - I05 — UTM ConOps: work-items/i05/index.md
+    - I06 — UTM Technical Standards: work-items/i06.md
+    - I07 — Feedback Sessions: work-items/i07.md
+    - I08 — NIDSP Spec: work-items/i08.md
+  - API Specifications: openapi/README.md
+  - Minutes: minutes/index.md
+  - Reference Documents: ref/index.md
+  - Nomenclature: nomenclature.md
+  - Bibliography: bibliography.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs
-mkdocs-bootswatch
+mkdocs-material


### PR DESCRIPTION
## Summary

Phase 1 of the repo rebaseline. Migrates the docs site to mkdocs-material and makes all content navigable and properly labelled.

### Changes

- **requirements.txt** — replaces `mkdocs-bootswatch` with `mkdocs-material`
- **mkdocs.yml** — full rewrite: material theme, tabs, section nav, search; exposes openapi/, minutes/, ref/ in nav for the first time; defines custom status labels
- **docs/status.md** — new Current Status page: work items, API specs, reference implementation, rebaseline progress all in one place
- **work-items/i01, i05, i06, i07, i08** — `status:` frontmatter added; renders as coloured badge in material nav sidebar

### Status labels applied

| Work item | Label |
|-----------|-------|
| I01 | published |
| I05 | published |
| I06 | paused |
| I07 | published |
| I08 | draft |

## Test plan

- [x] `mkdocs build --strict` — zero errors, zero warnings
- [ ] `mkdocs serve` — visual check: nav tabs visible, status badges in sidebar, Status page renders
- [ ] All nav links resolve (openapi, minutes, ref now exposed)

Closes #28 #29 #30 #31 #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)