### PR TITLE
D1: Add Seeds constants and SeedLoader for deterministic fixtures

### DIFF
--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/seeds/SeedLoader.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/seeds/SeedLoader.java
@@ -1,0 +1,104 @@
+package in.ispirt.pushpaka.dao.seeds;
+
+import in.ispirt.pushpaka.dao.DaoInstance;
+import in.ispirt.pushpaka.dao.entities.Address;
+import in.ispirt.pushpaka.dao.entities.CivilAviationAuthority;
+import in.ispirt.pushpaka.dao.entities.LegalEntity;
+import in.ispirt.pushpaka.dao.entities.Manufacturer;
+import in.ispirt.pushpaka.dao.entities.Operator;
+import in.ispirt.pushpaka.dao.entities.Person;
+import in.ispirt.pushpaka.dao.entities.Pilot;
+import in.ispirt.pushpaka.dao.entities.UasType;
+import in.ispirt.pushpaka.utils.Logging;
+import java.util.UUID;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+
+/**
+ * Writes {@link Seeds} fixtures to the database.
+ *
+ * <p>All operations are idempotent: if a record with the seed's stable UUID already
+ * exists it is left untouched. Call {@link #loadAll()} once at test setup or app
+ * startup to ensure a baseline dataset is present.
+ *
+ * <p>Persistence uses {@code Session.save()} directly (bypassing the entity static
+ * {@code create()} helpers which generate random UUIDs) so that seed IDs remain stable
+ * across runs.
+ */
+public class SeedLoader {
+
+  private final SessionFactory sf;
+
+  public SeedLoader() {
+    this.sf = DaoInstance.getInstance().getSessionFactory();
+  }
+
+  public SeedLoader(SessionFactory sf) {
+    this.sf = sf;
+  }
+
+  /**
+   * Loads all seed entities in dependency order. Safe to call multiple times.
+   */
+  public void loadAll() {
+    saveIfAbsent(Address.class, Seeds.ADDRESS_CAA_ID, Seeds.addressCaa());
+    saveIfAbsent(Address.class, Seeds.ADDRESS_MFR_ID, Seeds.addressManufacturer());
+    saveIfAbsent(Address.class, Seeds.ADDRESS_OPS_ID, Seeds.addressOperator());
+    saveIfAbsent(Address.class, Seeds.ADDRESS_PERSON_1_ID, Seeds.addressPerson1());
+
+    saveIfAbsent(LegalEntity.class, Seeds.LEGAL_ENTITY_CAA_ID, Seeds.legalEntityCaa());
+    saveIfAbsent(
+      LegalEntity.class,
+      Seeds.LEGAL_ENTITY_MFR_ID,
+      Seeds.legalEntityManufacturer()
+    );
+    saveIfAbsent(
+      LegalEntity.class,
+      Seeds.LEGAL_ENTITY_OPS_ID,
+      Seeds.legalEntityOperator()
+    );
+
+    saveIfAbsent(CivilAviationAuthority.class, Seeds.CAA_ID, Seeds.caa());
+    saveIfAbsent(Manufacturer.class, Seeds.MANUFACTURER_ID, Seeds.manufacturer());
+    saveIfAbsent(Operator.class, Seeds.OPERATOR_ID, Seeds.operator());
+
+    saveIfAbsent(Person.class, Seeds.PERSON_1_ID, Seeds.person1());
+    saveIfAbsent(Pilot.class, Seeds.PILOT_1_ID, Seeds.pilot1());
+
+    saveIfAbsent(UasType.class, Seeds.UAS_TYPE_1_ID, Seeds.uasType1());
+
+    Logging.info("SeedLoader: seed pass complete");
+  }
+
+  /**
+   * Persists {@code entity} only if no row with {@code id} exists in the table for
+   * {@code entityClass}. Returns true if a new row was inserted.
+   */
+  public <T> boolean saveIfAbsent(Class<T> entityClass, UUID id, T entity) {
+    Session s = sf.openSession();
+    Transaction tx = null;
+    try {
+      tx = s.beginTransaction();
+      T existing = s.get(entityClass, id);
+      if (existing != null) {
+        tx.commit();
+        return false;
+      }
+      s.save(entity);
+      s.flush();
+      tx.commit();
+      Logging.info("SeedLoader: inserted " + entityClass.getSimpleName() + " id=" + id);
+      return true;
+    } catch (Exception e) {
+      if (tx != null) tx.rollback();
+      Logging.warning(
+        "SeedLoader: failed to seed " + entityClass.getSimpleName() + " id=" + id
+      );
+      e.printStackTrace();
+      return false;
+    } finally {
+      s.close();
+    }
+  }
+}

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/seeds/Seeds.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/seeds/Seeds.java
@@ -1,0 +1,274 @@
+package in.ispirt.pushpaka.dao.seeds;
+
+import in.ispirt.pushpaka.dao.entities.Address;
+import in.ispirt.pushpaka.dao.entities.CivilAviationAuthority;
+import in.ispirt.pushpaka.dao.entities.LegalEntity;
+import in.ispirt.pushpaka.dao.entities.Manufacturer;
+import in.ispirt.pushpaka.dao.entities.Operator;
+import in.ispirt.pushpaka.dao.entities.Person;
+import in.ispirt.pushpaka.dao.entities.Pilot;
+import in.ispirt.pushpaka.dao.entities.UasType;
+import in.ispirt.pushpaka.models.Country;
+import in.ispirt.pushpaka.models.OperationCategory;
+import in.ispirt.pushpaka.models.State;
+import in.ispirt.pushpaka.models.UserStatus;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Named, deterministic fixture data for tests and local dev seeding.
+ *
+ * <p>Two kinds of constants are provided:
+ * <ul>
+ *   <li>SPICEDB_* — string resource IDs used by the SpiceDB AuthZ layer.</li>
+ *   <li>*_ID UUIDs + entity builder methods — Hibernate/DB layer fixtures with
+ *       stable, well-known IDs so seeds can be loaded idempotently.</li>
+ * </ul>
+ *
+ * <p>Builder methods return <em>unpersisted</em> entity objects. Use {@link SeedLoader}
+ * to write them to the database.
+ */
+public final class Seeds {
+
+  private Seeds() {}
+
+  // ── SpiceDB resource IDs ─────────────────────────────────────────────────
+
+  public static final String SPICEDB_CAA_RESOURCE_ID = "caa-authority";
+  public static final String SPICEDB_MANUFACTURER_RESOURCE_ID = "manufacturer-1";
+  public static final String SPICEDB_OPERATOR_RESOURCE_ID = "operator-1";
+  public static final String SPICEDB_DSSP_RESOURCE_ID = "dssp-1";
+  public static final String SPICEDB_TRADER_RESOURCE_ID = "trader-1";
+  public static final String SPICEDB_REPAIR_AGENCY_RESOURCE_ID = "repairagency-1";
+
+  public static final String SPICEDB_PLATFORM_USER_ID = "platform-user";
+  public static final String SPICEDB_CAA_ADMIN_USER_ID = "caa-user";
+  public static final String SPICEDB_MANUFACTURER_ADMIN_USER_ID = "manufacturer-user";
+  public static final String SPICEDB_OPERATOR_ADMIN_USER_ID = "operator-user";
+  public static final String SPICEDB_DSSP_ADMIN_USER_ID = "dssp-user";
+  public static final String SPICEDB_TRADER_ADMIN_USER_ID = "trader-user";
+  public static final String SPICEDB_REPAIR_AGENCY_ADMIN_USER_ID = "repairagency-user";
+
+  public static final String SPICEDB_PILOT_RESOURCE_1_ID = "pilot-resource-1";
+  public static final String SPICEDB_PILOT_RESOURCE_2_ID = "pilot-resource-2";
+  public static final String SPICEDB_PILOT_USER_1_ID = "pilot-user-1";
+  public static final String SPICEDB_PILOT_USER_2_ID = "pilot-user-2";
+
+  public static final String SPICEDB_UAS_RESOURCE_ID = "uas-1";
+  public static final String SPICEDB_UAS_TYPE_RESOURCE_ID = "uastype-1";
+
+  // ── Stable DB entity UUIDs ───────────────────────────────────────────────
+  // Prefix encodes entity type for easier debugging:
+  //   00000001-… Address
+  //   00000002-… LegalEntity
+  //   00000003-… CivilAviationAuthority
+  //   00000004-… Manufacturer
+  //   00000005-… Operator
+  //   00000006-… Person
+  //   00000007-… Pilot
+  //   00000008-… UasType
+
+  public static final UUID ADDRESS_CAA_ID = UUID.fromString(
+    "00000001-0000-0000-0000-000000000001"
+  );
+  public static final UUID ADDRESS_MFR_ID = UUID.fromString(
+    "00000001-0000-0000-0000-000000000002"
+  );
+  public static final UUID ADDRESS_OPS_ID = UUID.fromString(
+    "00000001-0000-0000-0000-000000000003"
+  );
+  public static final UUID ADDRESS_PERSON_1_ID = UUID.fromString(
+    "00000001-0000-0000-0000-000000000004"
+  );
+
+  public static final UUID LEGAL_ENTITY_CAA_ID = UUID.fromString(
+    "00000002-0000-0000-0000-000000000001"
+  );
+  public static final UUID LEGAL_ENTITY_MFR_ID = UUID.fromString(
+    "00000002-0000-0000-0000-000000000002"
+  );
+  public static final UUID LEGAL_ENTITY_OPS_ID = UUID.fromString(
+    "00000002-0000-0000-0000-000000000003"
+  );
+
+  public static final UUID CAA_ID = UUID.fromString(
+    "00000003-0000-0000-0000-000000000001"
+  );
+  public static final UUID MANUFACTURER_ID = UUID.fromString(
+    "00000004-0000-0000-0000-000000000001"
+  );
+  public static final UUID OPERATOR_ID = UUID.fromString(
+    "00000005-0000-0000-0000-000000000001"
+  );
+  public static final UUID PERSON_1_ID = UUID.fromString(
+    "00000006-0000-0000-0000-000000000001"
+  );
+  public static final UUID PILOT_1_ID = UUID.fromString(
+    "00000007-0000-0000-0000-000000000001"
+  );
+  public static final UUID UAS_TYPE_1_ID = UUID.fromString(
+    "00000008-0000-0000-0000-000000000001"
+  );
+
+  // ── Entity builders (unpersisted) ────────────────────────────────────────
+
+  public static Address addressCaa() {
+    Address a = new Address();
+    a.setId(ADDRESS_CAA_ID);
+    a.setLine1("Rajiv Gandhi Bhavan");
+    a.setLine2("Safdarjung Airport");
+    a.setCity("New Delhi");
+    a.setPinCode("110003");
+    a.setState(State.ANDHRA_PRADESH); // placeholder — State enum has no DELHI yet
+    a.setCountry(Country.IND);
+    return a;
+  }
+
+  public static Address addressManufacturer() {
+    Address a = new Address();
+    a.setId(ADDRESS_MFR_ID);
+    a.setLine1("Plot 42 MIDC Industrial Area");
+    a.setLine2("Chinchwad");
+    a.setCity("Pune");
+    a.setPinCode("411019");
+    a.setState(State.MAHARASHTRA);
+    a.setCountry(Country.IND);
+    return a;
+  }
+
+  public static Address addressOperator() {
+    Address a = new Address();
+    a.setId(ADDRESS_OPS_ID);
+    a.setLine1("14 Koramangala 5th Block");
+    a.setCity("Bengaluru");
+    a.setPinCode("560034");
+    a.setState(State.ANDHRA_PRADESH); // placeholder
+    a.setCountry(Country.IND);
+    return a;
+  }
+
+  public static Address addressPerson1() {
+    Address a = new Address();
+    a.setId(ADDRESS_PERSON_1_ID);
+    a.setLine1("123 ABC Housing Society");
+    a.setLine2("Bandra West");
+    a.setCity("Mumbai");
+    a.setPinCode("400050");
+    a.setState(State.MAHARASHTRA);
+    a.setCountry(Country.IND);
+    return a;
+  }
+
+  public static LegalEntity legalEntityCaa() {
+    OffsetDateTime n = OffsetDateTime.now();
+    LegalEntity le = new LegalEntity();
+    le.setId(LEGAL_ENTITY_CAA_ID);
+    le.setName("Civil Aviation Authority of India");
+    le.setCin("CAA0000001");
+    le.setGstin("27AABCC1234D1Z5");
+    le.setAddress(addressCaa());
+    le.setTimestampCreated(n);
+    le.setTimestampUpdated(n);
+    return le;
+  }
+
+  public static LegalEntity legalEntityManufacturer() {
+    OffsetDateTime n = OffsetDateTime.now();
+    LegalEntity le = new LegalEntity();
+    le.setId(LEGAL_ENTITY_MFR_ID);
+    le.setName("Test Drone Manufacturer Pvt Ltd");
+    le.setCin("MFR0000001");
+    le.setGstin("27AABCM1234D1Z5");
+    le.setAddress(addressManufacturer());
+    le.setTimestampCreated(n);
+    le.setTimestampUpdated(n);
+    return le;
+  }
+
+  public static LegalEntity legalEntityOperator() {
+    OffsetDateTime n = OffsetDateTime.now();
+    LegalEntity le = new LegalEntity();
+    le.setId(LEGAL_ENTITY_OPS_ID);
+    le.setName("Test Drone Operator Pvt Ltd");
+    le.setCin("OPS0000001");
+    le.setGstin("29AABCO1234D1Z5");
+    le.setAddress(addressOperator());
+    le.setTimestampCreated(n);
+    le.setTimestampUpdated(n);
+    return le;
+  }
+
+  public static CivilAviationAuthority caa() {
+    OffsetDateTime n = OffsetDateTime.now();
+    CivilAviationAuthority c = new CivilAviationAuthority();
+    c.setId(CAA_ID);
+    c.setLegalEntity(legalEntityCaa());
+    c.setCountry(Country.IND);
+    c.setTimestampCreated(n);
+    c.setTimestampUpdated(n);
+    return c;
+  }
+
+  public static Manufacturer manufacturer() {
+    OffsetDateTime n = OffsetDateTime.now();
+    Manufacturer m = new Manufacturer();
+    m.setId(MANUFACTURER_ID);
+    m.setLegalEntity(legalEntityManufacturer());
+    m.setTimestampCreated(n);
+    m.setTimestampUpdated(n);
+    return m;
+  }
+
+  public static Operator operator() {
+    OffsetDateTime n = OffsetDateTime.now();
+    Operator o = new Operator();
+    o.setId(OPERATOR_ID);
+    o.setLegalEntity(legalEntityOperator());
+    o.setTimestampCreated(n);
+    o.setTimestampUpdated(n);
+    return o;
+  }
+
+  public static Person person1() {
+    OffsetDateTime n = OffsetDateTime.now();
+    Person p = new Person(PERSON_1_ID);
+    p.setPhone("+919876543210");
+    p.setAadharId("1234-5678-9012");
+    p.setAddress(addressPerson1());
+    p.setTimestampCreated(n);
+    p.setTimestampUpdated(n);
+    p.setStatus(UserStatus.ACTIVE);
+    return p;
+  }
+
+  public static Pilot pilot1() {
+    OffsetDateTime n = OffsetDateTime.now();
+    Pilot pl = new Pilot();
+    pl.setId(PILOT_1_ID);
+    pl.setUser(person1());
+    pl.setTimestampCreated(n);
+    pl.setTimestampUpdated(n);
+    return pl;
+  }
+
+  public static UasType uasType1() {
+    OffsetDateTime n = OffsetDateTime.now();
+    UasType ut = new UasType();
+    ut.setId(UAS_TYPE_1_ID);
+    ut.setManufacturer(manufacturer());
+    ut.setModelNumber(1001);
+    ut.setMtow(2.5f);
+    ut.setApproved(false);
+    ut.setOperationCategory(OperationCategory.A);
+    try {
+      ut.setPhotoUrl(new URL("https://example.com/uas-type-1.jpg"));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException("Seed URL is malformed", e);
+    }
+    ut.setTimestampCreated(n);
+    ut.setTimestampUpdated(n);
+    return ut;
+  }
+}

--- a/reference-implementation/src/test/java/in/ispirt/pushpaka/unittests/AuthZTest.java
+++ b/reference-implementation/src/test/java/in/ispirt/pushpaka/unittests/AuthZTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import in.ispirt.pushpaka.authorisation.ResourceType;
 import in.ispirt.pushpaka.authorisation.utils.AuthZ;
 import in.ispirt.pushpaka.authorisation.utils.SpicedbClient;
+import in.ispirt.pushpaka.dao.seeds.Seeds;
 import java.util.ArrayList;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
@@ -24,7 +25,7 @@ public class AuthZTest {
   public static void setup() {
     authZ = new AuthZ();
     spicedbClient = authZ.getSpicedbClient();
-    authZ.setCaaResourceID("caa-authority");
+    authZ.setCaaResourceID(Seeds.SPICEDB_CAA_RESOURCE_ID);
     // Schema must be loaded before any permission checks can succeed.
     // testWriteSchema verifies this succeeded; we load here to guarantee ordering.
     spicedbClient.writeSchema(SpicedbClient.SPICEDDB_PERMISSION_FILE);
@@ -53,7 +54,7 @@ public class AuthZTest {
   public void testCreatePlatformUser() {
     // platform:digital-sky-platform#administrator@user:platform-user
 
-    boolean isSuccess = authZ.createPlatformAdmin("platform-user");
+    boolean isSuccess = authZ.createPlatformAdmin(Seeds.SPICEDB_PLATFORM_USER_ID);
     assertTrue(isSuccess);
   }
 
@@ -72,8 +73,8 @@ public class AuthZTest {
   public void testCreateCAAAdministrator() {
     // caa:caa-authority#administrator@user:caa-user
 
-    String caaResourceAdminID = "caa-user";
-    String platformAdminId = "platform-user";
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
+    String platformAdminId = Seeds.SPICEDB_PLATFORM_USER_ID;
 
     boolean isSuccess = authZ.createCAAAdmin(
       authZ.getCaaResourceID(),
@@ -88,8 +89,8 @@ public class AuthZTest {
   @Order(5)
   public void testCreateManufacturerAdministrator() {
     // manufacturer:manufacturer-1#administrator@user:manufacturer-user
-    String manufacturerResourceID = "manufacturer-1";
-    String manufacturerAdminUserID = "manufacturer-user";
+    String manufacturerResourceID = Seeds.SPICEDB_MANUFACTURER_RESOURCE_ID;
+    String manufacturerAdminUserID = Seeds.SPICEDB_MANUFACTURER_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createResoureTypeAdmin(
       ResourceType.MANUFACTURER,
@@ -104,8 +105,8 @@ public class AuthZTest {
   @Test
   @Order(6)
   public void testCreateTraderAdministrator() {
-    String traderResourceID = "trader-1";
-    String traderAdminUserID = "trader-user";
+    String traderResourceID = Seeds.SPICEDB_TRADER_RESOURCE_ID;
+    String traderAdminUserID = Seeds.SPICEDB_TRADER_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createResoureTypeAdmin(
       ResourceType.TRADER,
@@ -120,8 +121,8 @@ public class AuthZTest {
   @Test
   @Order(7)
   public void testCreateDSSPAdministrator() {
-    String dsspResourceID = "dssp-1";
-    String dsspAdminUserID = "dssp-user";
+    String dsspResourceID = Seeds.SPICEDB_DSSP_RESOURCE_ID;
+    String dsspAdminUserID = Seeds.SPICEDB_DSSP_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createResoureTypeAdmin(
       ResourceType.DSSP,
@@ -136,8 +137,8 @@ public class AuthZTest {
   @Test
   @Order(8)
   public void testCreateRepairAgencyAdministrator() {
-    String repairAgencyResourceID = "repairagency-1";
-    String repairAgencyAdminUserID = "repairagency-user";
+    String repairAgencyResourceID = Seeds.SPICEDB_REPAIR_AGENCY_RESOURCE_ID;
+    String repairAgencyAdminUserID = Seeds.SPICEDB_REPAIR_AGENCY_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createResoureTypeAdmin(
       ResourceType.REPAIRAGENCY,
@@ -155,8 +156,8 @@ public class AuthZTest {
     // operator:operator-1#administrator@user:operator-user
     // operator:operator-1#regulator@caa:caa-authority
 
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user";
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = Seeds.SPICEDB_OPERATOR_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createResoureTypeAdmin(
       ResourceType.OPERATOR,
@@ -171,8 +172,8 @@ public class AuthZTest {
   @Test
   @Order(10)
   public void testIsResourceAdministrator() {
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user";
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = Seeds.SPICEDB_OPERATOR_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.checkIsResourceAdmin(
       ResourceType.OPERATOR,
@@ -186,8 +187,8 @@ public class AuthZTest {
   @Test
   @Order(11)
   public void testIsResourceAdministratorNegative() {
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user-1";
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = "operator-user-1"; // intentionally wrong user for negative test
 
     boolean isSuccess = authZ.checkIsResourceAdmin(
       ResourceType.OPERATOR,
@@ -202,10 +203,10 @@ public class AuthZTest {
   @Order(12)
   public void testAddFirstPilotToOperator() {
     // pilot:default-pilot-group#member@user:pilot-user-2
-    String pilotResourceID = "pilot-resource-1";
-    String pilotUserID = "pilot-user-1";
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user";
+    String pilotResourceID = Seeds.SPICEDB_PILOT_RESOURCE_1_ID;
+    String pilotUserID = Seeds.SPICEDB_PILOT_USER_1_ID;
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = Seeds.SPICEDB_OPERATOR_ADMIN_USER_ID;
 
     boolean addPilot = authZ.addPilot(
       pilotResourceID,
@@ -231,10 +232,10 @@ public class AuthZTest {
   @Order(13)
   public void testAddSecondPilotToOperator() {
     // pilot:default-pilot-group#member@user:pilot-user-2
-    String pilotResourceID = "pilot-resource-2";
-    String pilotUserID = "pilot-user-2";
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user";
+    String pilotResourceID = Seeds.SPICEDB_PILOT_RESOURCE_2_ID;
+    String pilotUserID = Seeds.SPICEDB_PILOT_USER_2_ID;
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = Seeds.SPICEDB_OPERATOR_ADMIN_USER_ID;
 
     boolean addPilot = authZ.addPilot(
       pilotResourceID,
@@ -259,10 +260,9 @@ public class AuthZTest {
   @Test
   @Order(14)
   public void testRemoveFirstPilotToOperator() {
-    // pilot:default-pilot-group#member@user:pilot-user-
-    String pilotResourceID = "pilot-resource-1";
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user";
+    String pilotResourceID = Seeds.SPICEDB_PILOT_RESOURCE_1_ID;
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = Seeds.SPICEDB_OPERATOR_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.removePilotFromOperator(
       pilotResourceID,
@@ -276,10 +276,9 @@ public class AuthZTest {
   @Test
   @Order(15)
   public void testAddPilotToOperatoNegative() {
-    // pilot:default-pilot-group#member@user:pilot-user-2
-    String pilotResourceID = "pilot-resource";
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user-1";
+    String pilotResourceID = "pilot-resource"; // intentionally unknown resource
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = "operator-user-1"; // intentionally wrong admin
 
     boolean isSuccess = authZ.addPilotToOperator(
       pilotResourceID,
@@ -293,8 +292,8 @@ public class AuthZTest {
   @Test
   @Order(16)
   public void testFlightOperationsAdminNegative() {
-    String pilotUserID = "pilot-user-3";
-    String operatorResourceID = "operator-1";
+    String pilotUserID = "pilot-user-3"; // intentionally unknown pilot
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
 
     boolean isSuccess = authZ.isFlightOperationsAdmin(pilotUserID, operatorResourceID);
 
@@ -304,12 +303,12 @@ public class AuthZTest {
   @Test
   @Order(17)
   public void testCreateUASRelationships() {
-    String UASID = "uas-1";
-    String manufacturerResourceID = "manufacturer-1";
-    String manufacturerAdminUserID = "manufacturer-user";
+    String UASID = Seeds.SPICEDB_UAS_RESOURCE_ID;
+    String manufacturerResourceID = Seeds.SPICEDB_MANUFACTURER_RESOURCE_ID;
+    String manufacturerAdminUserID = Seeds.SPICEDB_MANUFACTURER_ADMIN_USER_ID;
 
-    String operatorResourceID = "operator-1";
-    String operatorAdminUserID = "operator-user";
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String operatorAdminUserID = Seeds.SPICEDB_OPERATOR_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createUASManufacturerRelationships(
       UASID,
@@ -331,9 +330,9 @@ public class AuthZTest {
   @Test
   @Order(18)
   public void testCreateUASTypeRelationships() {
-    String UASTypeID = "uastype-1";
-    String manufacturerResourceID = "manufacturer-1";
-    String manufacturerAdminUserID = "manufacturer-user";
+    String UASTypeID = Seeds.SPICEDB_UAS_TYPE_RESOURCE_ID;
+    String manufacturerResourceID = Seeds.SPICEDB_MANUFACTURER_RESOURCE_ID;
+    String manufacturerAdminUserID = Seeds.SPICEDB_MANUFACTURER_ADMIN_USER_ID;
 
     boolean isSuccess = authZ.createUASTypeRelationships(
       UASTypeID,
@@ -348,8 +347,8 @@ public class AuthZTest {
   @Test
   @Order(19)
   public void testApproveManufacturer() {
-    String manufacturerResourceID = "manufacturer-1";
-    String caaResourceAdminID = "caa-user";
+    String manufacturerResourceID = Seeds.SPICEDB_MANUFACTURER_RESOURCE_ID;
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
 
     boolean isApprover = authZ.approveResourceByRegulator(
       ResourceType.MANUFACTURER,
@@ -363,8 +362,8 @@ public class AuthZTest {
   @Test
   @Order(20)
   public void testApproveOperator() {
-    String operatorResourceID = "operator-1";
-    String caaResourceAdminID = "caa-user";
+    String operatorResourceID = Seeds.SPICEDB_OPERATOR_RESOURCE_ID;
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
 
     boolean isApprover = authZ.approveResourceByRegulator(
       ResourceType.OPERATOR,
@@ -378,8 +377,8 @@ public class AuthZTest {
   @Test
   @Order(21)
   public void testApproveDSSP() {
-    String dsspResourceID = "dssp-1";
-    String caaResourceAdminID = "caa-user";
+    String dsspResourceID = Seeds.SPICEDB_DSSP_RESOURCE_ID;
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
 
     boolean isApprover = authZ.approveResourceByRegulator(
       ResourceType.DSSP,
@@ -393,8 +392,8 @@ public class AuthZTest {
   @Test
   @Order(22)
   public void testApproveTrader() {
-    String traderResourceID = "trader-1";
-    String caaResourceAdminID = "caa-user";
+    String traderResourceID = Seeds.SPICEDB_TRADER_RESOURCE_ID;
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
 
     boolean isApprover = authZ.approveResourceByRegulator(
       ResourceType.TRADER,
@@ -408,8 +407,8 @@ public class AuthZTest {
   @Test
   @Order(23)
   public void testApproveRepairAgency() {
-    String repairAgencyResourceID = "repairagency-1";
-    String caaResourceAdminID = "caa-user";
+    String repairAgencyResourceID = Seeds.SPICEDB_REPAIR_AGENCY_RESOURCE_ID;
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
 
     boolean isApprover = authZ.approveResourceByRegulator(
       ResourceType.REPAIRAGENCY,
@@ -423,8 +422,8 @@ public class AuthZTest {
   @Test
   @Order(24)
   public void testLookupUASResourceOwnership() {
-    String UASID = "uas-1";
-    String manufacturerResourceID = "manufacturer-1";
+    String UASID = Seeds.SPICEDB_UAS_RESOURCE_ID;
+    String manufacturerResourceID = Seeds.SPICEDB_MANUFACTURER_RESOURCE_ID;
 
     boolean isSuccess = authZ.lookupUASResourceManufacturerOwnership(
       UASID,
@@ -437,8 +436,8 @@ public class AuthZTest {
   @Test
   @Order(25)
   public void testLookupUASResourceOwnershipNegative() {
-    String UASID = "uas";
-    String manufacturerResourceID = "manufacturer-1";
+    String UASID = "uas"; // intentionally unknown UAS
+    String manufacturerResourceID = Seeds.SPICEDB_MANUFACTURER_RESOURCE_ID;
 
     boolean isSuccess = authZ.lookupUASResourceManufacturerOwnership(
       UASID,
@@ -451,7 +450,7 @@ public class AuthZTest {
   @Test
   @Order(26)
   public void testLookupResourcesForRegulatorApprovals() {
-    String caaResourceAdminID = "caa-user";
+    String caaResourceAdminID = Seeds.SPICEDB_CAA_ADMIN_USER_ID;
 
     Set<String> resourceIdSetForApproval = authZ.lookupResourcesForRegulatorApproval(
       caaResourceAdminID
@@ -463,7 +462,7 @@ public class AuthZTest {
   @Test
   @Order(27)
   public void testPilotToOperators() {
-    String pilotResourceID = "pilot-resource-2";
+    String pilotResourceID = Seeds.SPICEDB_PILOT_RESOURCE_2_ID;
 
     Set<String> pilotToOperators = authZ.lookupPilotResource(pilotResourceID);
     System.out.println(pilotToOperators);


### PR DESCRIPTION
Closes #60.

## Summary

- **`Seeds.java`** — single source of truth for all fixture data used across tests and local dev seeding. Two families of constants:
  - `SPICEDB_*` — string resource IDs for the SpiceDB AuthZ layer (`"caa-authority"`, `"operator-1"`, etc.)
  - `*_ID` UUIDs + entity builder methods — stable, deterministic DB entity objects for Address, LegalEntity, CAA, Manufacturer, Operator, Person, Pilot, UasType
- **`SeedLoader.java`** — idempotent DB persistence layer. Uses `Session.get()` to check existence before calling `Session.save()` directly (bypasses entity `create()` helpers which generate random UUIDs, breaking idempotency)
- **`AuthZTest.java`** — all inline string literals (`"caa-authority"`, `"manufacturer-1"`, etc.) replaced with `Seeds.SPICEDB_*` constants; intentional negative-test sentinels annotated with comments

## Design notes

- `SeedLoader` intentionally bypasses entity static `create()` methods — those call `setId(UUID.randomUUID())` which would break idempotency
- Entity builder methods in `Seeds` return **unpersisted** objects; callers decide whether to persist
- Negative test values that must differ from seed values are kept as inline literals with a comment

## Test plan

- [ ] CI passes (`AuthZTest` all 30 ordered tests green)
- [ ] `Seeds.SPICEDB_*` constants match the values previously hardcoded in `AuthZTest`
- [ ] `SeedLoader.loadAll()` can be called twice without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)