### PR TITLE
#58 FlightPlan → AUT auto-issuance

### DIFF
--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/entities/AirspaceUsageToken.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/entities/AirspaceUsageToken.java
@@ -114,6 +114,31 @@ public class AirspaceUsageToken {
     }
   }
 
+  public static AirspaceUsageToken createForFlightPlan(SessionFactory sf, AirspaceUsageToken a)
+    throws DaoException {
+    Session s = sf.openSession();
+    Transaction t = null;
+    try {
+      t = s.beginTransaction();
+      FlightPlan fp = FlightPlan.get(sf, a.getFlightPlan().getId());
+      Pilot pilot = Pilot.get(sf, a.getPilot().getId());
+      Uas uas = Uas.get(sf, a.getUas().getId());
+      a.setFlightPlan(fp);
+      a.setPilot(pilot);
+      a.setUas(uas);
+      s.save(a);
+      s.flush();
+      t.commit();
+      s.refresh(a);
+      return a;
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new DaoException(DaoException.Code.UNKNOWN, "AirspaceUsageToken createForFlightPlan");
+    } finally {
+      s.close();
+    }
+  }
+
   public static List<AirspaceUsageToken> getAll(SessionFactory sf) throws DaoException {
     Session s = sf.openSession();
     Transaction t = null;

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/entities/Pilot.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/entities/Pilot.java
@@ -182,6 +182,26 @@ public class Pilot {
     }
   }
 
+  public static Pilot getByPersonId(SessionFactory sf, UUID personId) throws DaoException {
+    Session s = sf.openSession();
+    Transaction t = null;
+    try {
+      t = s.beginTransaction();
+      Pilot p = s
+        .createQuery("from Pilot where user.id = :personId", Pilot.class)
+        .setParameter("personId", personId)
+        .uniqueResult();
+      t.commit();
+      return p;
+    } catch (Exception e) {
+      e.printStackTrace();
+      if (t != null) t.rollback();
+      throw new DaoException(DaoException.Code.UNKNOWN, "Pilot getByPersonId");
+    } finally {
+      s.close();
+    }
+  }
+
   public static void delete(SessionFactory sf, UUID id) throws DaoException {
     Session s = sf.openSession();
     Transaction t = null;

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/service/FlightPlanService.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/service/FlightPlanService.java
@@ -1,8 +1,11 @@
 package in.ispirt.pushpaka.flightauthorisation.service;
 
+import com.nimbusds.jose.jwk.RSAKey;
 import in.ispirt.pushpaka.dao.DaoInstance;
+import in.ispirt.pushpaka.flightauthorisation.aut.AirspaceUsageTokenUtils;
 import in.ispirt.pushpaka.models.FlightPlan;
 import in.ispirt.pushpaka.registry.utils.DaoException;
+import in.ispirt.pushpaka.utils.Logging;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -19,6 +22,44 @@ public class FlightPlanService {
   public FlightPlan create(FlightPlan flightPlan, Jwt authentication) throws DaoException {
     in.ispirt.pushpaka.dao.entities.FlightPlan saved =
       in.ispirt.pushpaka.dao.entities.FlightPlan.create(sf(), FlightPlan.fromOa(flightPlan));
+
+    // Auto-issue an AUT for the saved flight plan.
+    try {
+      in.ispirt.pushpaka.models.AirspaceUsageToken autModel =
+        AirspaceUsageTokenUtils.createAirspaceUsageTokenObject(
+          flightPlan.getUas(),
+          flightPlan.getPilot(),
+          in.ispirt.pushpaka.models.FlightPlan.toOa(saved),
+          flightPlan.getStartTime(),
+          flightPlan.getEndTime()
+        );
+
+      RSAKey rsaKey = AirspaceUsageTokenUtils.getDigitalSkyRsaKey();
+      String autJwt = AirspaceUsageTokenUtils.signAirspaceUsageTokenObjectJWT(
+        rsaKey,
+        "digitalsky",
+        autModel,
+        "pushpaka-utm",
+        "utm-client",
+        authentication.getSubject(),
+        60,
+        0
+      );
+
+      in.ispirt.pushpaka.dao.entities.AirspaceUsageToken autEntity =
+        new in.ispirt.pushpaka.dao.entities.AirspaceUsageToken(autModel.getId());
+      in.ispirt.pushpaka.dao.entities.Uas uasRef = new in.ispirt.pushpaka.dao.entities.Uas();
+      uasRef.setId(saved.getUas().getId());
+      autEntity.setFlightPlan(new in.ispirt.pushpaka.dao.entities.FlightPlan(saved.getId()));
+      autEntity.setPilot(new in.ispirt.pushpaka.dao.entities.Pilot(saved.getPilot().getId()));
+      autEntity.setUas(uasRef);
+      in.ispirt.pushpaka.dao.entities.AirspaceUsageToken.createForFlightPlan(sf(), autEntity);
+
+      Logging.info("AUT issued for FlightPlan " + saved.getId() + " jwt=" + autJwt);
+    } catch (Exception e) {
+      Logging.warning("AUT issuance failed for FlightPlan " + saved.getId() + ": " + e.getMessage());
+    }
+
     return in.ispirt.pushpaka.models.FlightPlan.toOa(saved);
   }
 


### PR DESCRIPTION
## Summary

- `Pilot.java`: Add `getByPersonId(sf, personId)` to look up a Pilot by their Keycloak Person UUID (the `sub` claim in the JWT)
- `AirspaceUsageToken.java` (entity): Add `createForFlightPlan(sf, aut)` — persists an AUT with all three FKs (FK_flight_plan, FK_pilot, FK_uas) set, bypassing the Category C branching in the existing `create()` method
- `FlightPlanService.create()`: after saving the flight plan, auto-creates + RSA-signs an AUT using `AirspaceUsageTokenUtils`, persists it via `createForFlightPlan()`, and logs the signed JWT

## Behaviour

- `POST /flight-plans` response is **unchanged** — still returns the saved `FlightPlan`
- As a side-effect, an `AirspaceUsageToken` row is persisted in the DB, linked to the FlightPlan, Pilot, and UAS
- AUT issuance failure is non-fatal (logged as WARNING, flight plan still returned)
- The issued AUT is queryable via `GET /airspace-usage-tokens`

## Test plan

- [ ] Existing `AutTest` unit test still passes (no changes to `AirspaceUsageTokenUtils`)
- [ ] `java-ci.yml` runs `mvn test` on merge — `AuthZTest` and `EntityTests` should be green
- [ ] Manual smoke test: `POST /flight-plans` with valid JWT → check AUT row in DB via `GET /airspace-usage-tokens`

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)