### PR TITLE
#75 QGC-03: flight plan submission UI + AUT receipt

### DIFF
--- a/qgc-plugin/custom/CMakeLists.txt
+++ b/qgc-plugin/custom/CMakeLists.txt
@@ -24,6 +24,8 @@ set(QGC_RESOURCES ${QGC_RESOURCES} ${CUSTOM_RESOURCES} CACHE STRING "" FORCE)
 qt_add_library(PushpakaModule STATIC)
 
 set(CUSTOM_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/FlightAuthorisationClient.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/FlightAuthorisationClient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PushpakaPlugin.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/PushpakaPlugin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RegistryClient.h

--- a/qgc-plugin/custom/custom.qrc
+++ b/qgc-plugin/custom/custom.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/pushpaka">
         <file>qml/PushpakaStatusIndicator.qml</file>
+        <file>qml/FlightPlanPanel.qml</file>
     </qresource>
 </RCC>

--- a/qgc-plugin/custom/qml/FlightPlanPanel.qml
+++ b/qgc-plugin/custom/qml/FlightPlanPanel.qml
@@ -1,0 +1,84 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Flight plan submission panel.
+// Opens as a Popup; on submit calls PushpakaPlugin.submitFlightPlan().
+Popup {
+    id: root
+    width: 360
+    height: contentCol.implicitHeight + 48
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    property var _plugin: QGroundControl.corePlugin
+
+    // Close automatically when the AUT is received.
+    Connections {
+        target: root._plugin
+        function onAutChanged() {
+            if (root._plugin.hasValidAut) root.close()
+        }
+    }
+
+    ColumnLayout {
+        id: contentCol
+        anchors { left: parent.left; right: parent.right; top: parent.top; margins: 16 }
+        spacing: 12
+
+        Text {
+            text: "Submit Flight Plan"
+            font.pixelSize: 16
+            font.bold: true
+        }
+
+        Text { text: "Aircraft" }
+        ComboBox {
+            id: uasPicker
+            Layout.fillWidth: true
+            model: root._plugin.uasList
+            textRole: "id"
+        }
+
+        Text { text: "Start time (ISO 8601)" }
+        TextField {
+            id: startField
+            Layout.fillWidth: true
+            placeholderText: "2024-01-01T09:00:00+05:30"
+        }
+
+        Text { text: "End time (ISO 8601)" }
+        TextField {
+            id: endField
+            Layout.fillWidth: true
+            placeholderText: "2024-01-01T10:00:00+05:30"
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Item { Layout.fillWidth: true }
+            Button {
+                text: "Cancel"
+                onClicked: root.close()
+            }
+            Button {
+                text: busyIndicator.running ? "Submitting…" : "Submit"
+                enabled: !busyIndicator.running && uasPicker.currentIndex >= 0
+                         && startField.text.length > 0 && endField.text.length > 0
+                onClicked: {
+                    busyIndicator.running = true
+                    var uasId = root._plugin.uasList[uasPicker.currentIndex]["id"]
+                    root._plugin.submitFlightPlan(uasId, startField.text, endField.text)
+                }
+            }
+        }
+
+        BusyIndicator {
+            id: busyIndicator
+            running: false
+            Layout.alignment: Qt.AlignHCenter
+            visible: running
+        }
+    }
+}

--- a/qgc-plugin/custom/qml/PushpakaStatusIndicator.qml
+++ b/qgc-plugin/custom/qml/PushpakaStatusIndicator.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 // Pushpaka UTM status indicator for the QGC toolbar.
-// Shows: Not logged in / Logged in (no AUT) / AUT valid / AUT expired
-// Wired up in PushpakaPlugin::init() — expanded in #75.
+// Shows: Not logged in / Logged in (no AUT) / AUT valid
+// Click: triggers login if not authenticated, opens FlightPlanPanel otherwise.
 Rectangle {
     id: root
     width: statusText.implicitWidth + 16
@@ -11,12 +11,13 @@ Rectangle {
     radius: 4
     color: _bgColor()
 
-    property bool  authenticated: false  // bound to UserAuthentication.isAuthenticated
-    property bool  autValid:      false  // bound to AUT state (#75)
+    property var _plugin: QGroundControl.corePlugin
+    property bool authenticated: _plugin.userAuthentication.isAuthenticated
+    property bool autValid: _plugin.hasValidAut
 
     function _bgColor() {
         if (!authenticated) return "#555555"
-        if (!autValid)      return "#cc6600"
+        if (!autValid) return "#cc6600"
         return "#007700"
     }
 
@@ -27,13 +28,23 @@ Rectangle {
         font.pixelSize: 12
         text: {
             if (!root.authenticated) return "UTM: Login"
-            if (!root.autValid)      return "UTM: No AUT"
+            if (!root.autValid) return "UTM: No AUT"
             return "UTM: AUT Valid"
         }
     }
 
     MouseArea {
         anchors.fill: parent
-        // TODO (#74/#75): open login / flight plan panel on click
+        onClicked: {
+            if (!root.authenticated) {
+                root._plugin.userAuthentication.authorise()
+            } else {
+                flightPlanPanel.open()
+            }
+        }
+    }
+
+    FlightPlanPanel {
+        id: flightPlanPanel
     }
 }

--- a/qgc-plugin/custom/src/FlightAuthorisationClient.cpp
+++ b/qgc-plugin/custom/src/FlightAuthorisationClient.cpp
@@ -1,0 +1,78 @@
+#include "FlightAuthorisationClient.h"
+
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QProcessEnvironment>
+
+FlightAuthorisationClient::FlightAuthorisationClient(QObject* parent)
+    : QObject(parent), _nam(new QNetworkAccessManager(this))
+{
+}
+
+QString FlightAuthorisationClient::_flightAuthBase() const
+{
+    return QProcessEnvironment::systemEnvironment().value(QStringLiteral("FLIGHT_AUTH_URL"),
+                                                          QStringLiteral(DEFAULT_FLIGHT_AUTH_URL));
+}
+
+QNetworkRequest FlightAuthorisationClient::_authorizedRequest(const QUrl& url) const
+{
+    QNetworkRequest req(url);
+    req.setRawHeader("Authorization", QStringLiteral("Bearer %1").arg(_accessToken).toUtf8());
+    req.setRawHeader("Content-Type", "application/json");
+    req.setRawHeader("Accept", "application/json");
+    return req;
+}
+
+void FlightAuthorisationClient::submitFlightPlan(const QString& pilotId, const QString& uasId,
+                                                 const QString& startTime, const QString& endTime)
+{
+    QJsonObject body{
+        {QStringLiteral("id"), QJsonValue(QStringLiteral("00000000-0000-0000-0000-000000000000"))},
+        {QStringLiteral("pilot"), QJsonObject{{QStringLiteral("id"), pilotId}}},
+        {QStringLiteral("uas"), QJsonObject{{QStringLiteral("id"), uasId}}},
+        {QStringLiteral("start_time"), startTime},
+        {QStringLiteral("end_time"), endTime},
+    };
+
+    QUrl url(_flightAuthBase() + QStringLiteral("/api/v1/flightPlan"));
+    QNetworkReply* reply =
+        _nam->post(_authorizedRequest(url), QJsonDocument(body).toJson(QJsonDocument::Compact));
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            emit submitFailed(reply->errorString());
+            return;
+        }
+        QJsonObject fp = QJsonDocument::fromJson(reply->readAll()).object();
+        QString fpId = fp.value(QStringLiteral("id")).toString();
+        if (fpId.isEmpty()) {
+            emit submitFailed(QStringLiteral("flight plan response missing id"));
+            return;
+        }
+        _fetchAutForFlightPlan(fpId);
+    });
+}
+
+void FlightAuthorisationClient::_fetchAutForFlightPlan(const QString& flightPlanId)
+{
+    QUrl url(_flightAuthBase() + QStringLiteral("/api/v1/airspace-usage-tokens/by-flight-plan/") +
+             flightPlanId);
+    QNetworkReply* reply = _nam->get(_authorizedRequest(url));
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            emit submitFailed(reply->errorString());
+            return;
+        }
+        QJsonObject aut = QJsonDocument::fromJson(reply->readAll()).object();
+        QString signedJwt = aut.value(QStringLiteral("signed_jwt")).toString();
+        if (signedJwt.isEmpty()) {
+            emit submitFailed(QStringLiteral("AUT response missing signed_jwt"));
+            return;
+        }
+        emit autReceived(signedJwt);
+    });
+}

--- a/qgc-plugin/custom/src/FlightAuthorisationClient.h
+++ b/qgc-plugin/custom/src/FlightAuthorisationClient.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QNetworkRequest>
+
+/**
+ * HTTP client for the Pushpaka UTM Flight Authorisation service.
+ *
+ * submitFlightPlan() posts to POST /api/v1/flightPlan, then fetches the
+ * resulting signed AUT via GET /api/v1/airspace-usage-tokens/by-flight-plan/{id}.
+ *
+ * Base URL: http://localhost:8083  (override via FLIGHT_AUTH_URL env var)
+ */
+class FlightAuthorisationClient : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FlightAuthorisationClient(QObject* parent = nullptr);
+
+    void setAccessToken(const QString& token) { _accessToken = token; }
+
+    void submitFlightPlan(const QString& pilotId, const QString& uasId, const QString& startTime,
+                          const QString& endTime);
+
+signals:
+    void autReceived(const QString& signedJwt);
+    void submitFailed(const QString& error);
+
+private:
+    QString _flightAuthBase() const;
+    QNetworkRequest _authorizedRequest(const QUrl& url) const;
+    void _fetchAutForFlightPlan(const QString& flightPlanId);
+
+    static constexpr const char* DEFAULT_FLIGHT_AUTH_URL = "http://localhost:8083";
+
+    QNetworkAccessManager* _nam = nullptr;
+    QString _accessToken;
+};

--- a/qgc-plugin/custom/src/PushpakaPlugin.cpp
+++ b/qgc-plugin/custom/src/PushpakaPlugin.cpp
@@ -1,7 +1,9 @@
 #include "PushpakaPlugin.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QUrl>
 
+#include "FlightAuthorisationClient.h"
 #include "RegistryClient.h"
 #include "UserAuthentication.h"
 
@@ -24,13 +26,16 @@ void PushpakaPlugin::init()
 
     _userAuth = new UserAuthentication(this);
     _registry = new RegistryClient(this);
+    _flightAuth = new FlightAuthorisationClient(this);
 
-    // When the user logs in, fetch pilot profile + UAS list from the registry.
+    // On login: fetch pilot profile + UAS list; propagate token to flight auth client.
     connect(_userAuth, &UserAuthentication::authenticationChanged, this, [this]() {
         if (!_userAuth->isAuthenticated()) {
             return;
         }
-        _registry->setAccessToken(_userAuth->accessToken());
+        const QString token = _userAuth->accessToken();
+        _registry->setAccessToken(token);
+        _flightAuth->setAccessToken(token);
         _registry->fetchPilotMe();
         _registry->fetchUasList();
     });
@@ -50,6 +55,35 @@ void PushpakaPlugin::init()
         _registry, &RegistryClient::fetchFailed, this, [](const QString& op, const QString& err) {
             qWarning("[pushpaka] registry fetch failed: %s — %s", qPrintable(op), qPrintable(err));
         });
+
+    connect(_flightAuth, &FlightAuthorisationClient::autReceived, this,
+            [this](const QString& signedJwt) {
+                _autJwt = signedJwt;
+                _hasValidAut = true;
+                emit autChanged();
+            });
+
+    connect(_flightAuth, &FlightAuthorisationClient::submitFailed, this, [](const QString& err) {
+        qWarning("[pushpaka] flight plan submission failed: %s", qPrintable(err));
+    });
 }
 
 void PushpakaPlugin::cleanup() { QGCCorePlugin::cleanup(); }
+
+const QVariantList& PushpakaPlugin::toolBarIndicators()
+{
+    if (_toolBarIndicators.isEmpty()) {
+        _toolBarIndicators.append(QVariant::fromValue(
+            QUrl::fromUserInput(QStringLiteral("qrc:/pushpaka/qml/PushpakaStatusIndicator.qml"))));
+        for (const QVariant& v : QGCCorePlugin::toolBarIndicators()) {
+            _toolBarIndicators.append(v);
+        }
+    }
+    return _toolBarIndicators;
+}
+
+void PushpakaPlugin::submitFlightPlan(const QString& uasId, const QString& startTime,
+                                      const QString& endTime)
+{
+    _flightAuth->submitFlightPlan(_pilotId, uasId, startTime, endTime);
+}

--- a/qgc-plugin/custom/src/PushpakaPlugin.h
+++ b/qgc-plugin/custom/src/PushpakaPlugin.h
@@ -6,6 +6,7 @@
 
 class UserAuthentication;
 class RegistryClient;
+class FlightAuthorisationClient;
 
 /**
  * Pushpaka UTM QGC plugin.
@@ -13,15 +14,18 @@ class RegistryClient;
  * Entry point for all Pushpaka-specific behaviour:
  *   - Keycloak OAuth2 authentication (UserAuthentication)
  *   - Registry / pilot / UAS lookup  (RegistryClient — #74)
- *   - Flight plan submission + AUT   (future: #75)
+ *   - Flight plan submission + AUT   (FlightAuthorisationClient — #75)
  *   - Arm pre-check enforcement      (future: #76)
  */
 class PushpakaPlugin : public QGCCorePlugin
 {
     Q_OBJECT
 
+    Q_PROPERTY(UserAuthentication* userAuthentication READ userAuthentication CONSTANT)
     Q_PROPERTY(QString pilotId READ pilotId NOTIFY pilotChanged)
     Q_PROPERTY(QVariantList uasList READ uasList NOTIFY uasListChanged)
+    Q_PROPERTY(bool hasValidAut READ hasValidAut NOTIFY autChanged)
+    Q_PROPERTY(QString autJwt READ autJwt NOTIFY autChanged)
 
 public:
     explicit PushpakaPlugin(QObject* parent = nullptr);
@@ -32,20 +36,33 @@ public:
     // QGCCorePlugin overrides
     void init() override;
     void cleanup() override;
+    const QVariantList& toolBarIndicators() override;
 
     UserAuthentication* userAuthentication() const { return _userAuth; }
     RegistryClient* registryClient() const { return _registry; }
 
     QString pilotId() const { return _pilotId; }
     QVariantList uasList() const { return _uasList; }
+    bool hasValidAut() const { return _hasValidAut; }
+    QString autJwt() const { return _autJwt; }
+
+    Q_INVOKABLE void submitFlightPlan(const QString& uasId, const QString& startTime,
+                                      const QString& endTime);
 
 signals:
     void pilotChanged();
     void uasListChanged();
+    void autChanged();
 
 private:
     UserAuthentication* _userAuth = nullptr;
     RegistryClient* _registry = nullptr;
+    FlightAuthorisationClient* _flightAuth = nullptr;
+
     QString _pilotId;
     QVariantList _uasList;
+    bool _hasValidAut = false;
+    QString _autJwt;
+
+    QVariantList _toolBarIndicators;
 };

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/entities/AirspaceUsageToken.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/dao/entities/AirspaceUsageToken.java
@@ -76,6 +76,17 @@ public class AirspaceUsageToken {
     this.uas = id;
   }
 
+  @Column(name = "signed_jwt", length = 4096)
+  public String signedJwt;
+
+  public String getSignedJwt() {
+    return signedJwt;
+  }
+
+  public void setSignedJwt(String signedJwt) {
+    this.signedJwt = signedJwt;
+  }
+
   // Hibernate needs a default (no-arg) constructor to create model objects.
   public AirspaceUsageToken() {}
 
@@ -134,6 +145,29 @@ public class AirspaceUsageToken {
     } catch (Exception e) {
       e.printStackTrace();
       throw new DaoException(DaoException.Code.UNKNOWN, "AirspaceUsageToken createForFlightPlan");
+    } finally {
+      s.close();
+    }
+  }
+
+  public static AirspaceUsageToken getByFlightPlanId(SessionFactory sf, UUID flightPlanId)
+    throws DaoException {
+    Session s = sf.openSession();
+    Transaction t = null;
+    try {
+      t = s.beginTransaction();
+      AirspaceUsageToken aut = s
+        .createQuery(
+          "from AirspaceUsageToken where flightPlan.id = :fpId",
+          AirspaceUsageToken.class
+        )
+        .setParameter("fpId", flightPlanId)
+        .uniqueResult();
+      t.commit();
+      return aut;
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new DaoException(DaoException.Code.UNKNOWN, "AirspaceUsageToken getByFlightPlanId");
     } finally {
       s.close();
     }

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/api/AirspaceUsageTokenApiController.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/api/AirspaceUsageTokenApiController.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +41,24 @@ public class AirspaceUsageTokenApiController implements AirspaceUsageTokenApi {
   @Override
   public Optional<NativeWebRequest> getRequest() {
     return Optional.ofNullable(request);
+  }
+
+  // Returns the AUT (including signed_jwt) linked to the given flight plan.
+  @GetMapping("/airspace-usage-tokens/by-flight-plan/{flightPlanId}")
+  public ResponseEntity<AirspaceUsageToken> getAutByFlightPlan(
+    @PathVariable("flightPlanId") UUID flightPlanId
+  ) {
+    try {
+      return ResponseEntity.ok(airspaceUsageTokenService.getByFlightPlanId(flightPlanId));
+    } catch (DaoException e) {
+      System.err.println("Exception: " + e.toString());
+      e.printStackTrace(System.err);
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    } catch (Exception e) {
+      System.err.println("Exception: " + e.toString());
+      e.printStackTrace(System.err);
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 
   @Override

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/service/AirspaceUsageTokenService.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/service/AirspaceUsageTokenService.java
@@ -41,6 +41,15 @@ public class AirspaceUsageTokenService {
     return in.ispirt.pushpaka.models.AirspaceUsageToken.toOa(entity);
   }
 
+  public AirspaceUsageToken getByFlightPlanId(UUID flightPlanId) throws DaoException {
+    in.ispirt.pushpaka.dao.entities.AirspaceUsageToken entity =
+      in.ispirt.pushpaka.dao.entities.AirspaceUsageToken.getByFlightPlanId(sf(), flightPlanId);
+    if (entity == null) {
+      throw new DaoException(DaoException.Code.NOT_FOUND, "AirspaceUsageToken");
+    }
+    return in.ispirt.pushpaka.models.AirspaceUsageToken.toOa(entity);
+  }
+
   public AirspaceUsageToken update(UUID autId, AirspaceUsageToken aut) throws DaoException {
     in.ispirt.pushpaka.dao.entities.AirspaceUsageToken updated =
       in.ispirt.pushpaka.dao.entities.AirspaceUsageToken.update(

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/service/FlightPlanService.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/flightauthorisation/service/FlightPlanService.java
@@ -53,6 +53,7 @@ public class FlightPlanService {
       autEntity.setFlightPlan(new in.ispirt.pushpaka.dao.entities.FlightPlan(saved.getId()));
       autEntity.setPilot(new in.ispirt.pushpaka.dao.entities.Pilot(saved.getPilot().getId()));
       autEntity.setUas(uasRef);
+      autEntity.setSignedJwt(autJwt);
       in.ispirt.pushpaka.dao.entities.AirspaceUsageToken.createForFlightPlan(sf(), autEntity);
 
       Logging.info("AUT issued for FlightPlan " + saved.getId() + " jwt=" + autJwt);

--- a/reference-implementation/src/main/java/in/ispirt/pushpaka/models/AirspaceUsageToken.java
+++ b/reference-implementation/src/main/java/in/ispirt/pushpaka/models/AirspaceUsageToken.java
@@ -37,6 +37,7 @@ public class AirspaceUsageToken {
   private OffsetDateTime endTime;
   private AirspaceUsageTokenState state;
   private AirspaceUsageTokenAttenuations attenuations;
+  private String signedJwt;
 
   @NotNull
   @Schema(name = "id", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -129,6 +130,16 @@ public class AirspaceUsageToken {
     this.attenuations = attenuations;
   }
 
+  @Schema(name = "signed_jwt", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("signed_jwt")
+  public String getSignedJwt() {
+    return signedJwt;
+  }
+
+  public void setSignedJwt(String signedJwt) {
+    this.signedJwt = signedJwt;
+  }
+
   public String toJsonString() {
 //    Gson gson = new GsonBuilder().setPrettyPrinting().create();
 //    JsonElement jsonElement = gson.toJsonTree(this);
@@ -200,6 +211,7 @@ public class AirspaceUsageToken {
     } else {
       le.setFlightPlan(FlightPlan.toOa(x.getFlightPlan()));
     }
+    le.setSignedJwt(x.getSignedJwt());
     return le;
   }
 }


### PR DESCRIPTION
## Summary

### Backend
- `AirspaceUsageToken` entity: `signed_jwt` column (Hibernate auto-DDL adds it); `getByFlightPlanId()` HQL query
- `AirspaceUsageToken` model: `signedJwt` field serialised as `"signed_jwt"` in JSON; wired through `toOa()`
- `FlightPlanService.create()`: sets `autEntity.signedJwt = autJwt` before persisting — the signed JWT is now stored in DB
- `AirspaceUsageTokenService`: new `getByFlightPlanId(UUID)`
- `AirspaceUsageTokenApiController`: new `GET /airspace-usage-tokens/by-flight-plan/{flightPlanId}` endpoint (not part of the generated interface)

### QGC Plugin
- **`FlightAuthorisationClient`** (new): two-step HTTP sequence — `POST /api/v1/flightPlan` → on success, `GET /api/v1/airspace-usage-tokens/by-flight-plan/{id}` → emits `autReceived(signedJwt)`. Base URL `FLIGHT_AUTH_URL` env var, default `http://localhost:8083`
- **`PushpakaPlugin`**: adds `_flightAuth`, `_hasValidAut`, `_autJwt`; `Q_PROPERTY bool hasValidAut`, `QString autJwt`, `UserAuthentication* userAuthentication`; `Q_INVOKABLE submitFlightPlan(uasId, startTime, endTime)`; overrides `toolBarIndicators()` to inject `PushpakaStatusIndicator.qml` at front of toolbar
- **`PushpakaStatusIndicator.qml`**: binds `authenticated`/`autValid` to real plugin properties; click triggers `authorise()` or opens `FlightPlanPanel`
- **`FlightPlanPanel.qml`** (new): `Popup` with UAS `ComboBox`, ISO-8601 time fields, submit/cancel; closes automatically when `autChanged` fires with a valid AUT

## Test plan
- [ ] `C++ format check` passes
- [ ] `QGC cmake configure` detects plugin with new source files
- [ ] `build-and-test` Java CI passes — new column added via Hibernate auto-DDL, existing tests unaffected
- [ ] Manual: full stack → login in QGC → indicator turns orange → click → submit flight plan → indicator turns green

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)