### PR TITLE
docs/spec: close 3 spec gaps + QGC manual test instructions

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -35,38 +35,42 @@ Provides the operator-facing UI for flight planning, monitoring, and control.
 **Upstream repo:** https://github.com/mavlink/qgroundcontrol
 
 **Relationship to Pushpaka:**
-QGroundControl was forked and extended with Keycloak-based user authentication,
-allowing the GCS to authenticate operators against the Pushpaka identity provider
-before flight operations.
+Pushpaka extends QGroundControl using its official **Custom Build** mechanism — a
+`custom/` directory that is overlaid at build time without forking or patching the
+QGC source tree. The plugin is maintained in this repo under `qgc-plugin/`.
 
-### Pushpaka-specific work: Keycloak OAuth integration
+### Architecture: Custom Build plugin
 
-Commit: `Add UserAuthentication via Keycloak using Qt OAuth` (2024-07-19, Sayandeep Purkayasth)
+The `qgc-plugin/custom/` directory is a self-contained QGC custom build that adds:
 
-**Files added/modified:**
-
-| File | Purpose |
-|------|---------|
-| `src/UserAuthentication.h` | Qt `QObject` exposing `isAuthenticated` property and `authorise()` slot |
-| `src/UserAuthentication.cpp` | OAuth2 Authorization Code Flow via `QOAuth2AuthorizationCodeFlow`; connects to Keycloak at `http://localhost:8080/realms/digitalsky` |
-| `src/ui/toolbar/UserAuthentication.qml` | QML element placeholder (stub, imports `UserAuthentication`) |
-| `src/ui/toolbar/MainStatusIndicator.qml` | UI toolbar hook for auth status |
-| `src/QGCApplication.h`, `src/main.cc`, `src/api/QGCCorePlugin.cc` | Integration points wiring `UserAuthentication` into the QGC application lifecycle |
-| `src/CMakeLists.txt`, `qgroundcontrol.pro`, `qgroundcontrol.qrc` | Build system additions |
+| Component | Purpose |
+|-----------|---------|
+| `PushpakaPlugin` (`QGCCorePlugin` subclass) | Top-level plugin; wires all components together; exposes properties to QML |
+| `UserAuthentication` | OAuth2 Authorization Code Flow via Keycloak; exposes `isAuthenticated` and `authorise()` to QML |
+| `RegistryClient` | HTTP client for the Pushpaka Registry (port 8082); fetches pilot profile and UAS list after login |
+| `FlightAuthorisationClient` | HTTP client for the Flight Authorisation service (port 8083); submits flight plans and retrieves signed AUTs |
+| `PushpakaStatusIndicator.qml` | Toolbar status indicator (injected via `toolBarIndicators()` override); shows auth/AUT state; opens login or flight plan panel on click |
+| `FlightPlanPanel.qml` | Popup panel for submitting flight plans (UAS selection, start/end time, submit button, busy indicator) |
 
 **Key implementation details:**
-- Uses Qt's `QOAuth2AuthorizationCodeFlow` (Authorization Code Flow)
-- Keycloak realm: `pushpaka`
-- Client ID: `backend`
-- Keycloak URL: `http://localhost:18080`
-- Redirect: local HTTP reply handler on port 8000
-- `isAuthenticated` property bindable from QML for UI reactivity
-- Browser-based auth flow via `QDesktopServices::openUrl`
+- No fork of QGC — upstream is a git submodule at `qgc-plugin/qgroundcontrol`; `custom/` is symlinked/placed at `qgc-plugin/qgroundcontrol/custom`
+- OAuth2: Keycloak realm `pushpaka`, client `utm-client`, redirect handler on `http://localhost:8000`
+- Registry URL: env var `REGISTRY_URL`, default `http://localhost:8082`
+- Flight authorisation URL: env var `FLIGHT_AUTH_URL`, default `http://localhost:8083`
+- Toolbar indicator injected via `QGCCorePlugin::toolBarIndicators()` override
+- Flight plan submission is a two-call chain: `POST /api/v1/flightPlan` → `GET /api/v1/airspace-usage-tokens/by-flight-plan/{fpId}` → signed JWT returned and stored
 
-**Status:** In progress. Proof-of-concept OAuth integration exists. Full wiring to registry and flight-auth APIs is active work (see [#67](https://github.com/iSPIRT/pushpaka/issues/67)).
+**Status:** Active — login, pilot/UAS fetch, flight plan submission, and AUT receipt are implemented (issues [#67](https://github.com/iSPIRT/pushpaka/issues/67), [#74](https://github.com/iSPIRT/pushpaka/issues/74), [#75](https://github.com/iSPIRT/pushpaka/issues/75)).
 
-**To work on this:**
-1. Fork `https://github.com/mavlink/qgroundcontrol`
-2. Re-apply the changes above against a current upstream commit
-3. Start the devcontainer stack (`docker compose -f .devcontainer/docker-compose.yml up`)
-4. Keycloak is available at `http://localhost:18080`, realm `pushpaka`, client `backend`
+**Manual test instructions:** See [QGC Integration Testing](ref/qgc-testing.md).
+
+**To build:**
+```bash
+cd qgc-plugin
+# Symlink the custom build into the QGC source tree
+ln -s $(pwd)/custom qgroundcontrol/custom
+
+cd qgroundcontrol
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build --target QGroundControl -j$(nproc)
+```

--- a/docs/openapi/flight-authorisation.yaml
+++ b/docs/openapi/flight-authorisation.yaml
@@ -263,6 +263,32 @@ paths:
                   $ref: '#/components/schemas/FlightPlan'
       security:
       - jwt: []
+  /api/v1/airspace-usage-tokens/by-flight-plan/{flightPlanId}:
+    get:
+      tags:
+      - airspaceUsageTokens
+      summary: Find AirspaceUsageToken by FlightPlan ID
+      description: Returns the AirspaceUsageToken issued for a given FlightPlan
+      operationId: getAirspaceUsageTokenByFlightPlanId
+      parameters:
+      - name: flightPlanId
+        in: path
+        description: ID of the FlightPlan whose AUT is to be returned
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AirspaceUsageToken'
+        "404":
+          description: AirspaceUsageToken not found for the given FlightPlan
+      security:
+      - jwt: []
   /api/v1/airspaceUsageToken/find:
     get:
       tags:
@@ -637,6 +663,13 @@ components:
           - TERMINATED
         attentuations:
           $ref: '#/components/schemas/AirspaceUsageTokenAttenuations'
+        signed_jwt:
+          type: string
+          description: >
+            RSA-signed JWT issued by the Pushpaka UTM authority when the flight
+            plan is approved. Present only when the AUT has been issued; absent
+            for manually created AUT records.
+          readOnly: true
     AirspaceUsageTokenAttenuations:
       type: object
       properties:

--- a/docs/openapi/registry.yaml
+++ b/docs/openapi/registry.yaml
@@ -453,6 +453,26 @@ paths:
           description: Invalid repairAgency value
       security:
       - jwt: []
+  /api/v1/pilots/me:
+    get:
+      tags:
+      - pilot
+      summary: Get the calling pilot's own profile
+      description: >
+        Returns the Pilot record whose Person ID matches the JWT subject claim.
+        Use this after login to obtain the pilotId needed for flight plan submission.
+      operationId: getMyPilotProfile
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pilot'
+        "404":
+          description: No pilot found for the authenticated user
+      security:
+      - jwt: []
   /api/v1/pilot/{pilotId}:
     get:
       tags:

--- a/docs/ref/index.md
+++ b/docs/ref/index.md
@@ -1,3 +1,4 @@
 # Reference Documents
 
 1. [National UTM Policy Discussion Draft](./draft-utm-policy/)
+2. [QGC Integration Testing](./qgc-testing.md)

--- a/docs/ref/qgc-testing.md
+++ b/docs/ref/qgc-testing.md
@@ -1,0 +1,156 @@
+# QGC Integration Testing
+
+Step-by-step instructions for manually testing the Pushpaka QGroundControl plugin
+end-to-end: from stack startup through pilot login, flight plan submission, and
+AUT receipt.
+
+---
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- QGroundControl built with the Pushpaka custom plugin (see [Integrations — QGroundControl](../integrations.md))
+- Maven and Java 17 for the reference implementation services
+
+---
+
+## 1. Start the backing services
+
+```bash
+cd reference-implementation
+docker compose up -d
+```
+
+This starts:
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| PostgreSQL | 15432 | Database |
+| Keycloak | 18080 | Identity provider (realm: `pushpaka`) |
+| SpiceDB | 50051 | Authorisation |
+
+Wait ~15 seconds for Keycloak to fully initialise before starting the Java services.
+
+---
+
+## 2. Start the Registry service
+
+```bash
+cd reference-implementation
+SPRING_PROFILES_ACTIVE=registry mvn compile exec:java \
+  -Dexec.mainClass="in.ispirt.pushpaka.registry.RegistryService"
+```
+
+Registry listens on **port 8082**. Confirm it is ready when you see:
+
+```
+Started RegistryService in X seconds
+```
+
+---
+
+## 3. Seed the database (first run only)
+
+On first run the reference implementation seeds deterministic fixture data
+(pilot, UAS, manufacturer, etc.) automatically via `SeedLoader` on startup.
+No manual step is needed.
+
+---
+
+## 4. Start the Flight Authorisation service
+
+```bash
+cd reference-implementation
+SPRING_PROFILES_ACTIVE=flightauthorisation mvn compile exec:java \
+  -Dexec.mainClass="in.ispirt.pushpaka.flightauthorisation.FlightAuthorisationService"
+```
+
+Flight authorisation listens on **port 8083**.
+
+---
+
+## 5. Launch QGroundControl
+
+```bash
+cd qgc-plugin/qgroundcontrol
+./build/QGroundControl
+```
+
+---
+
+## 6. Login flow
+
+1. The Pushpaka status indicator appears in the QGC toolbar (top-right area).
+   Its initial state is **grey / unauthenticated**.
+
+2. Click the indicator. A browser window opens at the Keycloak login page
+   (`http://localhost:18080/realms/pushpaka/...`).
+
+3. Log in with a seeded pilot account (default fixture: `pilot@example.com` /
+   `password` — check `Seeds.java` for current values).
+
+4. After successful login, the browser redirects to `http://localhost:8000`
+   (the OAuth callback handler). The QGC window regains focus.
+
+5. The plugin:
+   - Calls `GET /api/v1/pilots/me` on the Registry to resolve the pilot UUID
+   - Calls `GET /api/v1/uas` to fetch the available UAS list
+
+6. The toolbar indicator turns **amber** (authenticated, no active AUT).
+
+---
+
+## 7. Submit a flight plan
+
+1. Click the toolbar indicator again. The **Flight Plan Panel** popup opens.
+
+2. Select a UAS from the dropdown (populated from the UAS list fetched above).
+
+3. Enter a start time and end time in ISO 8601 format, e.g.:
+   ```
+   Start: 2026-06-01T10:00:00Z
+   End:   2026-06-01T10:30:00Z
+   ```
+
+4. Click **Submit**.
+
+5. The panel shows a busy indicator while the plugin:
+   - Posts `POST /api/v1/flightPlan` to the Flight Authorisation service
+   - Polls `GET /api/v1/airspace-usage-tokens/by-flight-plan/{fpId}` to retrieve the
+     signed AUT JWT
+
+6. On success the panel closes automatically.
+
+7. The toolbar indicator turns **green** (authenticated, valid AUT).
+
+---
+
+## 8. Verify the AUT
+
+To inspect the issued JWT directly, query the flight authorisation service:
+
+```bash
+# List all flight plans
+curl http://localhost:8083/api/v1/flightPlan/find \
+  -H "Authorization: Bearer <your-keycloak-access-token>"
+
+# Get AUT for a specific flight plan
+curl http://localhost:8083/api/v1/airspace-usage-tokens/by-flight-plan/<flight-plan-uuid> \
+  -H "Authorization: Bearer <your-keycloak-access-token>"
+```
+
+The response includes a `signed_jwt` field containing the RSA-signed JWT issued
+by the Pushpaka UTM authority.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Toolbar indicator does not appear | Custom plugin not detected by QGC build | Confirm `custom/` is present in `qgc-plugin/qgroundcontrol/` and rebuild |
+| Browser does not open on click | `QDesktopServices` issue | Run QGC from a desktop session (not SSH) |
+| Login succeeds but indicator stays grey | Pilot not found in DB | Check `GET /api/v1/pilots/me` returns 200; ensure DB is seeded and pilot's Keycloak UUID matches the `user.id` in the DB |
+| Flight plan submit fails immediately | Registry or flight-auth service not running | Confirm both services are up on ports 8082 / 8083 |
+| AUT fetch returns 404 | AUT issuance failed silently | Check flight-auth service logs for `AUT issuance failed for FlightPlan` warning |
+| `signed_jwt` field is null | RSA key not found | Confirm `AirspaceUsageTokenUtils.getDigitalSkyRsaKey()` can locate the key on the classpath |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,9 @@ nav:
     - I08 — NIDSP Spec: work-items/i08.md
   - API Specifications: openapi/README.md
   - Minutes: minutes/index.md
-  - Reference Documents: ref/index.md
+  - Reference Documents:
+    - Overview: ref/index.md
+    - QGC Integration Testing: ref/qgc-testing.md
   - Integrations: integrations.md
   - Nomenclature: nomenclature.md
   - Bibliography: bibliography.md


### PR DESCRIPTION
## Summary

- **OpenAPI spec sync**: 3 gaps between the reference implementation and the published specs are now closed
  - `registry.yaml`: added `GET /api/v1/pilots/me` (resolves pilot from JWT subject)
  - `flight-authorisation.yaml`: added `signed_jwt` field to `AirspaceUsageToken` schema
  - `flight-authorisation.yaml`: added `GET /api/v1/airspace-usage-tokens/by-flight-plan/{flightPlanId}`
- **Integrations page**: rewrote QGC section — old text described a stale fork-based approach; new text documents the Custom Build plugin architecture implemented in #74/#75
- **QGC testing guide**: new `docs/ref/qgc-testing.md` with step-by-step manual test instructions (stack startup → login → flight plan submission → AUT receipt → troubleshooting table)
- **Nav update**: QGC testing page added to Reference Documents in `mkdocs.yml`

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally — 0 errors)
- [ ] OpenAPI changes visible in rendered spec pages on docs site
- [ ] QGC testing guide reachable at Reference Documents → QGC Integration Testing
- [ ] Integrations page QGC section reflects Custom Build plugin approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)