### PR TITLE
#85 QGC-04: ARM pre-check — block arming without valid AUT

### DIFF
--- a/qgc-plugin/custom/qml/PushpakaStatusIndicator.qml
+++ b/qgc-plugin/custom/qml/PushpakaStatusIndicator.qml
@@ -4,6 +4,8 @@ import QtQuick.Controls
 // Pushpaka UTM status indicator for the QGC toolbar.
 // Shows: Not logged in / Logged in (no AUT) / AUT valid
 // Click: triggers login if not authenticated, opens FlightPlanPanel otherwise.
+// ARM pre-check (#76): watches active vehicle armed state; reactively disarms
+// and shows a warning if pilot attempts to arm without a valid AUT.
 Rectangle {
     id: root
     width: statusText.implicitWidth + 16
@@ -41,6 +43,34 @@ Rectangle {
             } else {
                 flightPlanPanel.open()
             }
+        }
+    }
+
+    // ARM pre-check: watch the active vehicle's armed state.
+    // If the vehicle arms without a valid AUT, immediately disarm and warn.
+    Connections {
+        target: QGroundControl.multiVehicleManager.activeVehicle
+        ignoreUnknownSignals: true
+
+        function onArmedChanged(armed) {
+            if (armed && !root.autValid) {
+                QGroundControl.multiVehicleManager.activeVehicle.setArmed(false, false)
+                armBlockedDialog.open()
+            }
+        }
+    }
+
+    Dialog {
+        id: armBlockedDialog
+        title: "Arming blocked — no valid AUT"
+        modal: true
+        anchors.centerIn: Overlay.overlay
+        standardButtons: Dialog.Ok
+
+        Label {
+            text: "A valid Airspace Usage Token is required before arming.\n\nClick the UTM indicator to log in and submit a flight plan."
+            wrapMode: Text.WordWrap
+            width: 320
         }
     }
 


### PR DESCRIPTION
## Summary

Reactive ARM enforcement in QML: if the vehicle arms without a valid AUT, immediately disarm and show a blocking dialog directing the pilot to the UTM indicator.

## Implementation

`PushpakaStatusIndicator.qml` — added:
- `Connections { target: QGroundControl.multiVehicleManager.activeVehicle }` watching `onArmedChanged`
- On `armed && !autValid` → `setArmed(false, false)` + `armBlockedDialog.open()`
- `ignoreUnknownSignals: true` — safe when no vehicle connected
- `Dialog` with clear message pointing pilot to login + flight plan flow

No changes to C++, CMakeLists, or any other file.

## Why reactive not preventive

QGC's `QGCCorePlugin` API only provides a hook for **incoming** MAVLink messages (`mavlinkMessage()`), not outgoing commands. Intercepting the ARM before it's sent would require patching `Vehicle::setArmed()` in core QGC — outside the custom build scope. Reactive disarm is the correct approach for an illustrative implementation.

## Test plan

- [ ] Build passes (C++ format check + cmake configure)
- [ ] Without AUT: arm attempt → immediate disarm + dialog shown
- [ ] With valid AUT: arm proceeds normally
- [ ] No vehicle connected: indicator loads without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)