### PR TITLE
#77 + #90: SITL e2e + baseline fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,20 +294,30 @@ Options:
 
 For the full manual QGC walkthrough (login → flight plan → AUT → green indicator) see [`docs/ref/qgc-testing.md`](docs/ref/qgc-testing.md).
 
-### ArduPilot SITL (optional)
+### With ArduPilot SITL
 
-To add a simulated vehicle:
+To add a simulated vehicle and test ARM enforcement end-to-end:
 
 ```bash
-docker compose -f .devcontainer/docker-compose.yml --profile sitl up
+# 1. Start SITL alongside the core stack
+docker compose -f .devcontainer/docker-compose.yml --profile sitl up -d
+
+# 2. Start the MAVLink bridge (blocks ARM without active AUT)
+export PUSHPAKA_TOKEN=<keycloak-bearer-token>
+python3 sitl-bridge/bridge.py --require-aut
 ```
 
 | Endpoint | Protocol | Purpose |
 |----------|----------|---------|
-| `localhost:5760` | TCP | MAVLink (autopilot stream) |
-| `localhost:14550` | UDP | QGC connection |
+| `localhost:5760` | TCP | MAVLink — bridge connects here |
+| `localhost:14550` | UDP | QGC connects here |
 
-QGC auto-detects the SITL vehicle on `localhost:14550` (UDP).
+See [`docs/ref/qgc-testing.md`](docs/ref/qgc-testing.md) for the full SITL ARM enforcement scenario (steps 9–14).
+
+### Windows
+
+`e2e-smoke.sh` requires bash. On Windows use **WSL** or **Git Bash**.
+`sitl-bridge/bridge.py` and `sitl-bridge/bridge.py --require-aut` run natively on Windows.
 
 ---
 

--- a/docs/ref/qgc-testing.md
+++ b/docs/ref/qgc-testing.md
@@ -86,8 +86,8 @@ cd qgc-plugin/qgroundcontrol
 2. Click the indicator. A browser window opens at the Keycloak login page
    (`http://localhost:18080/realms/pushpaka/...`).
 
-3. Log in with a seeded pilot account (default fixture: `pilot@example.com` /
-   `password` — check `Seeds.java` for current values).
+3. Log in with the seeded pilot account: `test.pilot.0@test.com` / `test`
+   (from `docker/keycloak-realm-pushpaka-test.json`).
 
 4. After successful login, the browser redirects to `http://localhost:8000`
    (the OAuth callback handler). The QGC window regains focus.
@@ -141,6 +141,68 @@ curl http://localhost:8083/api/v1/airspace-usage-tokens/by-flight-plan/<flight-p
 
 The response includes a `signed_jwt` field containing the RSA-signed JWT issued
 by the Pushpaka UTM authority.
+
+---
+
+## SITL scenario (optional — full ARM enforcement test)
+
+This scenario extends the basic QGC test with an ArduPilot SITL vehicle to
+verify that ARM is blocked without an AUT and allowed once one is issued.
+
+### 9. Start SITL
+
+```bash
+# From repo root — starts the ArduPilot SITL container in addition to the core stack
+docker compose -f .devcontainer/docker-compose.yml --profile sitl up -d
+```
+
+SITL exposes MAVLink on `localhost:5760` (TCP, bridge) and `localhost:14550` (UDP, QGC).
+
+### 10. Start the MAVLink bridge
+
+```bash
+# Get a token first
+TOKEN=$(curl -s -X POST http://localhost:18080/realms/pushpaka/protocol/openid-connect/token \
+  -d "grant_type=password&client_id=backend&username=test.pilot.0@test.com&password=test" \
+  | jq -r .access_token)
+
+export PUSHPAKA_TOKEN=$TOKEN
+python3 sitl-bridge/bridge.py --require-aut
+```
+
+The bridge logs HEARTBEAT state and enforces AUT on ARM commands.
+
+### 11. Connect QGC to SITL
+
+In QGC: **Application Settings → Comm Links → Add** → UDP, port 14550.
+QGC auto-detects the ArduCopter vehicle on connection.
+
+### 12. Attempt ARM without AUT
+
+In QGC, attempt to arm the vehicle (Fly view → Arm slider or MAVLink console).
+
+Expected:
+- QGC plugin: indicator stays amber; reactive disarm fires immediately + dialog shown
+- Bridge: logs `ARM BLOCKED — no active AUT; sending disarm`
+
+### 13. Get AUT and ARM successfully
+
+1. Click the UTM indicator → log in → submit a flight plan
+2. Indicator turns green (AUT issued)
+3. Attempt ARM again
+
+Expected:
+- QGC plugin: ARM proceeds (indicator is green, `hasValidAut = true`)
+- Bridge: logs `ARM allowed — valid AUT found`
+- Vehicle arms normally in SITL
+
+### 14. Verify in bridge log
+
+```
+ARM command received — checking AUT …
+ARM allowed — valid AUT found
+Vehicle ARMED
+```
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
     - Overview: work-items/index.md
     - I01 — ConOps V1: work-items/i01.md
     - I05 — UTM ConOps: work-items/i05/index.md
+    - I05 — State of the Art: work-items/i05/state-of-the-art.md
     - I06 — UTM Technical Standards: work-items/i06.md
     - I07 — Feedback Sessions: work-items/i07.md
     - I08 — NIDSP Spec: work-items/i08.md

--- a/reference-implementation/src/test/scripts/e2e-smoke.sh
+++ b/reference-implementation/src/test/scripts/e2e-smoke.sh
@@ -6,10 +6,11 @@
 #
 # Usage:
 #   ./e2e-smoke.sh              # boot + smoke + launch QGC
+#   ./e2e-smoke.sh --sitl       # same + start SITL + start MAVLink bridge
 #   ./e2e-smoke.sh --no-qgc     # boot + smoke only (no QGC launch)
 #   ./e2e-smoke.sh --teardown   # stop services and docker stack
 #
-# Requirements: docker, mvn (Java 17), curl, jq
+# Requirements: docker, mvn (Java 17), curl, jq, python3 (for --sitl)
 
 set -euo pipefail
 
@@ -35,11 +36,13 @@ PILOT_PASS="${PUSHPAKA_PASSWORD:-test}"
 
 LAUNCH_QGC=true
 TEARDOWN=false
+WITH_SITL=false
 
 for arg in "$@"; do
   case $arg in
     --no-qgc)   LAUNCH_QGC=false ;;
     --teardown) TEARDOWN=true ;;
+    --sitl)     WITH_SITL=true ;;
   esac
 done
 
@@ -117,8 +120,12 @@ if [[ "$TEARDOWN" == "true" ]]; then
     kill "$(cat "$LOG_DIR/flightauth.pid")" 2>/dev/null && echo "  Flight auth stopped" || true
     rm -f "$LOG_DIR/flightauth.pid"
   fi
+  if [[ -f "$LOG_DIR/bridge.pid" ]]; then
+    kill "$(cat "$LOG_DIR/bridge.pid")" 2>/dev/null && echo "  MAVLink bridge stopped" || true
+    rm -f "$LOG_DIR/bridge.pid"
+  fi
   cd "$REPO_ROOT"
-  docker compose -f "$DEVCONTAINER_DIR/docker-compose.yml" down
+  docker compose -f "$DEVCONTAINER_DIR/docker-compose.yml" --profile sitl down
   echo "  Docker stack stopped"
   exit 0
 fi
@@ -134,7 +141,11 @@ echo ""
 echo -e "${BOLD}Phase 1 — Boot docker stack${RESET}"
 
 cd "$REPO_ROOT"
-docker compose -f "$DEVCONTAINER_DIR/docker-compose.yml" up -d --remove-orphans
+if [[ "$WITH_SITL" == "true" ]]; then
+  docker compose -f "$DEVCONTAINER_DIR/docker-compose.yml" --profile sitl up -d --remove-orphans
+else
+  docker compose -f "$DEVCONTAINER_DIR/docker-compose.yml" up -d --remove-orphans
+fi
 echo "  Containers started"
 
 # Wait for Postgres
@@ -156,6 +167,15 @@ else
   echo -e "\n${RED}Keycloak failed to start. Check docker logs.${RESET}"
   docker compose -f "$DEVCONTAINER_DIR/docker-compose.yml" logs keycloak | tail -20
   exit 1
+fi
+
+# Wait for SITL MAVLink port
+if [[ "$WITH_SITL" == "true" ]]; then
+  if wait_for_port "SITL (MAVLink)" "localhost" "5760" 60; then
+    record "SITL reachable (port 5760)" "PASS"
+  else
+    record "SITL reachable (port 5760)" "FAIL" "SITL container may not have started"
+  fi
 fi
 
 echo ""
@@ -232,6 +252,20 @@ else
 fi
 
 AUTH_HEADER="Authorization: Bearer $TOKEN"
+
+# Start MAVLink bridge if --sitl and token available
+if [[ "$WITH_SITL" == "true" && -n "$TOKEN" ]]; then
+  echo "  Starting MAVLink bridge (logs → tmp/bridge.log)"
+  PUSHPAKA_TOKEN="$TOKEN" python3 "$REPO_ROOT/sitl-bridge/bridge.py" --require-aut \
+    > "$LOG_DIR/bridge.log" 2>&1 &
+  echo $! > "$LOG_DIR/bridge.pid"
+  sleep 2
+  if kill -0 "$(cat "$LOG_DIR/bridge.pid")" 2>/dev/null; then
+    record "MAVLink bridge startup" "PASS"
+  else
+    record "MAVLink bridge startup" "FAIL" "check tmp/bridge.log"
+  fi
+fi
 
 if [[ -n "$TOKEN" ]]; then
   # GET /api/v1/uas/find
@@ -368,6 +402,15 @@ if [[ "$LAUNCH_QGC" == "true" ]]; then
   echo "  5. Click again — the Flight Plan Panel opens"
   echo "  6. Select a UAS, enter start/end time, click Submit"
   echo "  7. Indicator turns green (valid AUT issued)"
+  if [[ "$WITH_SITL" == "true" ]]; then
+    echo ""
+    echo -e "  ${CYAN}SITL steps:${RESET}"
+    echo "  8. In QGC: Settings → Comm Links → Add → UDP port 14550 → Connect"
+    echo "  9. Attempt ARM without AUT → should be blocked + dialog shown"
+    echo "  10. Complete steps 2–7 above to get AUT"
+    echo "  11. Attempt ARM again → should succeed (indicator is green)"
+    echo "  12. Check bridge log: tmp/bridge.log for ARM decisions"
+  fi
   echo ""
   echo -e "  Full guide: ${CYAN}docs/ref/qgc-testing.md${RESET}"
   echo ""
@@ -375,6 +418,7 @@ fi
 
 echo -e "  Logs:  $LOG_DIR/registry.log"
 echo -e "         $LOG_DIR/flightauth.log"
+[[ "$WITH_SITL" == "true" ]] && echo -e "         $LOG_DIR/bridge.log"
 echo -e "  Stop:  $0 --teardown"
 echo ""
 


### PR DESCRIPTION
## Summary

Completes the QGC thread (#77) and resolves all three baseline audit findings (#90).

### #77 — SITL end-to-end

**`e2e-smoke.sh --sitl`:**
- Starts docker with `--profile sitl` (adds ArduPilot SITL container)
- Waits for SITL MAVLink port 5760
- After token fetch: starts `sitl-bridge/bridge.py --require-aut` in background with `PUSHPAKA_TOKEN`
- Manual checklist extended with SITL steps (connect QGC to SITL, ARM blocked without AUT, ARM succeeds after AUT)
- `--teardown` stops bridge + uses `--profile sitl` for docker down

**`docs/ref/qgc-testing.md`:**
- New SITL scenario section (steps 9–14): start SITL → start bridge → connect QGC → verify ARM blocked → get AUT → verify ARM allowed → check bridge log

### #90 — Baseline fixes

| Fix | File |
|-----|------|
| Stale credentials (`pilot@example.com` → `test.pilot.0@test.com / test`) | `docs/ref/qgc-testing.md` |
| `state-of-the-art.md` added to mkdocs nav (was orphaned) | `mkdocs.yml` |
| README: sitl-bridge instructions + Windows note (WSL/Git Bash for smoke script) | `README.md` |

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally — 0 errors)
- [ ] `e2e-smoke.sh --help` / usage comment shows `--sitl`
- [ ] `e2e-smoke.sh --sitl` starts SITL profile and bridge (requires SITL container)
- [ ] `e2e-smoke.sh --teardown` stops bridge cleanly
- [ ] state-of-the-art.md visible in published docs nav under I05

🤖 Generated with [Claude Code](https://claude.com/claude-code)