### PR TITLE
#92 Architecture diagram: Mermaid system topology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,51 @@ pushpaka/
 
 ---
 
+## Architecture
+
+```mermaid
+flowchart LR
+
+    subgraph operator["Operator Workstation"]
+        QGC["QGroundControl\n(Pushpaka Plugin)"]
+    end
+
+    subgraph identity["Identity"]
+        KC["Keycloak\nport 18080"]
+    end
+
+    subgraph services["Backend Services"]
+        REG["Registry Service\nport 8082"]
+        FA["Flight Auth Service\nport 8083"]
+    end
+
+    subgraph storage["Storage & AuthZ"]
+        PG[("PostgreSQL\nport 15432")]
+        SDB["SpiceDB\nport 50051"]
+    end
+
+    subgraph sitl["SITL — optional"]
+        ARDUPILOT["ArduPilot SITL\nUDP :14550  TCP :5760"]
+        BRIDGE["MAVLink Bridge\nbridge.py"]
+    end
+
+    QGC -->|"OAuth2\nAuthorisation Code"| KC
+    QGC -->|"REST\nGET /pilots/me\nGET /uas"| REG
+    QGC -->|"REST\nPOST /flightPlan\nGET /airspace-usage-tokens/..."| FA
+    QGC -->|"MAVLink UDP :14550"| ARDUPILOT
+
+    REG --> PG
+    REG -->|"AuthZ checks"| SDB
+    FA --> PG
+
+    BRIDGE -->|"MAVLink TCP :5760\nHEARTBEAT + ARM intercept"| ARDUPILOT
+    BRIDGE -->|"REST\nGET /airspaceUsageToken/find"| FA
+```
+
+Standalone source: [`docs/architecture.mmd`](docs/architecture.mmd)
+
+---
+
 ## Working Group Docs
 
 Work items, meeting minutes, OpenAPI specs, and reference documents live under `docs/` and are published as a static site via MkDocs.

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,36 @@
+flowchart LR
+
+    subgraph operator["Operator Workstation"]
+        QGC["QGroundControl\n(Pushpaka Plugin)"]
+    end
+
+    subgraph identity["Identity"]
+        KC["Keycloak\nport 18080"]
+    end
+
+    subgraph services["Backend Services"]
+        REG["Registry Service\nport 8082"]
+        FA["Flight Auth Service\nport 8083"]
+    end
+
+    subgraph storage["Storage & AuthZ"]
+        PG[("PostgreSQL\nport 15432")]
+        SDB["SpiceDB\nport 50051"]
+    end
+
+    subgraph sitl["SITL — optional"]
+        ARDUPILOT["ArduPilot SITL\nUDP :14550  TCP :5760"]
+        BRIDGE["MAVLink Bridge\nbridge.py"]
+    end
+
+    QGC -->|"OAuth2\nAuthorisation Code"| KC
+    QGC -->|"REST\nGET /pilots/me\nGET /uas"| REG
+    QGC -->|"REST\nPOST /flightPlan\nGET /airspace-usage-tokens/..."| FA
+    QGC -->|"MAVLink UDP :14550"| ARDUPILOT
+
+    REG --> PG
+    REG -->|"AuthZ checks"| SDB
+    FA --> PG
+
+    BRIDGE -->|"MAVLink TCP :5760\nHEARTBEAT + ARM intercept"| ARDUPILOT
+    BRIDGE -->|"REST\nGET /airspaceUsageToken/find"| FA


### PR DESCRIPTION
## Summary

Adds a Mermaid architecture diagram showing the full Pushpaka system topology.
GitHub renders `mermaid` code blocks natively so no extra tooling needed.

## Diagram covers

- **QGC Plugin** → Keycloak (OAuth2), Registry (REST), Flight Auth (REST), SITL (MAVLink)
- **Registry Service** → PostgreSQL, SpiceDB (AuthZ)
- **Flight Auth Service** → PostgreSQL
- **ArduPilot SITL** ↔ MAVLink bridge (`bridge.py`) → Flight Auth
- All connections labelled with protocol and key API calls

## Files

| File | Purpose |
|------|---------|
| `docs/architecture.mmd` | Standalone Mermaid source |
| `README.md` | Embedded `mermaid` block in new Architecture section; link to source |

## Test plan

- [ ] Diagram renders correctly on the PR page (GitHub Mermaid preview)
- [ ] Docs CI passes (architecture.mmd is not in mkdocs nav — no build impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)