### PR TITLE
fix #95: docs build on all branches, deploy only on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [master, dev]
+    branches: ['**']
   workflow_dispatch:
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/master'
         run: mkdocs gh-deploy --force
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ mkdocs build --strict
 
 ### Deploy
 
-GitHub Actions auto-deploys to GitHub Pages on push to the `dev` branch. To deploy manually:
+GitHub Actions auto-deploys to GitHub Pages on push to the `master` branch. To deploy manually:
 
 ```bash
 mkdocs gh-deploy


### PR DESCRIPTION
## Summary

- `main.yml` now triggers on all branch pushes (strict build acts as a PR lint gate)
- Deploy step gated to `master` only — prevents `dev` pushes from overwriting the live GitHub Pages site
- README updated: "auto-deploys on push to `master`" (was `dev`)

Closes #95