### PR TITLE
fix #99: enable attr_list so {:target="_blank"} renders correctly

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ theme:
     - search.highlight
     - search.suggest
 
+markdown_extensions:
+  - attr_list
+
 extra:
   status:
     draft: Work in progress


### PR DESCRIPTION
## Summary

- Adds `attr_list` to `markdown_extensions` in `mkdocs.yml`
- Fixes the docs homepage where `pushpaka.ispirt.in{:target="_blank"}` was rendering the attribute syntax as literal text instead of opening the link in a new tab

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally — 0 errors)
- [ ] Docs CI (`main.yml`) green on this PR

Closes #99